### PR TITLE
shutdown telemetryclient in close

### DIFF
--- a/src/main/java/io/micrometer/newrelic/NewRelicRegistry.java
+++ b/src/main/java/io/micrometer/newrelic/NewRelicRegistry.java
@@ -154,6 +154,12 @@ public class NewRelicRegistry extends StepMeterRegistry {
   }
 
   @Override
+  public void close() {
+    super.close();
+    this.telemetryClient.shutdown();
+  }
+
+  @Override
   protected void publish() {
     List<List<Meter>> partitionedData = MeterPartition.partition(this, config.batchSize());
     for (List<Meter> batch : partitionedData) {

--- a/src/main/java/io/micrometer/newrelic/NewRelicRegistry.java
+++ b/src/main/java/io/micrometer/newrelic/NewRelicRegistry.java
@@ -156,6 +156,8 @@ public class NewRelicRegistry extends StepMeterRegistry {
   @Override
   public void close() {
     super.close();
+    // NOTE: telemetryClient.shutdown is called after calling "close"
+    // so that we can flush the last metricBatch
     this.telemetryClient.shutdown();
   }
 

--- a/src/test/java/io/micrometer/newrelic/NewRelicRegistryTest.java
+++ b/src/test/java/io/micrometer/newrelic/NewRelicRegistryTest.java
@@ -304,4 +304,11 @@ class NewRelicRegistryTest {
     newRelicRegistry.publish();
     verify(telemetryClient).sendBatch(expectedBatch);
   }
+
+  @Test
+  @DisplayName("closing telemetryClient's executor")
+  void testClose() {
+    newRelicRegistry.close();
+    verify(telemetryClient).shutdown();
+  }
 }


### PR DESCRIPTION
issue: https://github.com/newrelic/micrometer-registry-newrelic/issues/80
related PR: https://github.com/paypay/newrelic-telemetry-sdk-java/pull/1

## Background
When TelemetryClient, which NewRelicRegistry uses, is getting error from NewRelic, it retries sending metrics. Threads TelemetryClient uses are non-daemon threads(user threads), so it can prevents JVM from shutting down.

Related PR attached is fixing to set the threads as daemon threads, but even we are using daemon threads, NewRelicRegistry should clean up its resource while it's destroyed.

(But If the attached PR is merged, this PR can be low priority)

## Change
This PR just shutdown NewRelicRegistry's telemetryClient while it is closed.
